### PR TITLE
fix(mcp): treat "default" budgetId as configured default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stephendolan/ynab-cli",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "A command-line interface for You Need a Budget (YNAB)",
   "type": "module",
   "main": "./dist/cli.js",

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -43,7 +43,7 @@ export class YnabClient {
   }
 
   async getBudgetId(budgetIdOrDefault?: string): Promise<string> {
-    const budgetId = budgetIdOrDefault || config.getDefaultBudget() || process.env.YNAB_BUDGET_ID;
+    const budgetId = (budgetIdOrDefault && budgetIdOrDefault !== 'default' ? budgetIdOrDefault : undefined) || config.getDefaultBudget() || process.env.YNAB_BUDGET_ID;
 
     if (!budgetId) {
       throw new YnabCliError(


### PR DESCRIPTION
## Summary

- Treat literal `"default"` budgetId as a fallback signal, resolving to the configured default budget instead of sending it to the YNAB API (which 404s)

## Release

Patch release: 2.8.1 → 2.8.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)