### PR TITLE
fix(auth): show the interactive login prompt instead of erasing it

### DIFF
--- a/src/commands/auth.test.ts
+++ b/src/commands/auth.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { PassThrough } from 'stream';
+import { promptForToken, readTokenFromStdin } from './auth.js';
+
+describe('promptForToken', () => {
+  it('emits the prompt as part of readline (not a bare pre-write)', async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    let captured = '';
+    output.on('data', (chunk) => {
+      captured += chunk.toString();
+    });
+
+    const promise = promptForToken(input, output);
+    input.write('my-secret-token\n');
+    const token = await promise;
+
+    expect(token).toBe('my-secret-token');
+    // Regression: prompt must reach output via readline so it isn't cleared off (Warp).
+    expect(captured).toContain('Enter YNAB Personal Access Token:');
+  });
+
+  it('trims surrounding whitespace from the entered token', async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const promise = promptForToken(input, output);
+    input.write('  padded-token  \n');
+    await expect(promise).resolves.toBe('padded-token');
+  });
+});
+
+describe('readTokenFromStdin', () => {
+  it('resolves with the trimmed token when piped in', async () => {
+    const stdin = new PassThrough();
+    const promise = readTokenFromStdin(stdin);
+    stdin.write('  piped-token\n');
+    stdin.end();
+    await expect(promise).resolves.toBe('piped-token');
+  });
+
+  it('resolves empty when stdin closes without data', async () => {
+    const stdin = new PassThrough();
+    const promise = readTokenFromStdin(stdin);
+    stdin.end();
+    await expect(promise).resolves.toBe('');
+  });
+
+  it('rejects when the stream errors', async () => {
+    const stdin = new PassThrough();
+    const promise = readTokenFromStdin(stdin);
+    const boom = new Error('stream boom');
+    stdin.emit('error', boom);
+    await expect(promise).rejects.toBe(boom);
+  });
+});

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -1,29 +1,36 @@
 import { Command } from 'commander';
 import { createInterface } from 'readline';
+import type { Readable, Writable } from 'stream';
 import { auth } from '../lib/auth.js';
 import { outputJson } from '../lib/output.js';
 import { client } from '../lib/api-client.js';
 import { withErrorHandling } from '../lib/command-utils.js';
 import { YnabCliError } from '../lib/errors.js';
 
-function readTokenFromStdin(): Promise<string> {
+const TOKEN_PROMPT = 'Enter YNAB Personal Access Token: ';
+
+export function readTokenFromStdin(stdin: Readable = process.stdin): Promise<string> {
   return new Promise((resolve, reject) => {
     let data = '';
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', (chunk) => { data += chunk; });
-    process.stdin.on('end', () => resolve(data.trim()));
-    process.stdin.on('error', reject);
+    stdin.setEncoding('utf8');
+    stdin.on('data', (chunk) => {
+      data += chunk;
+    });
+    stdin.on('end', () => resolve(data.trim()));
+    stdin.on('error', reject);
   });
 }
 
-function promptForToken(): Promise<string> {
+// Pass the prompt as readline's question() query, not a separate write: readline
+// clears and reprints its line on refresh (ESC[1G ESC[0J), erasing any prompt
+// written outside its knowledge — invisibly on terminals like Warp.
+export function promptForToken(
+  input: Readable = process.stdin,
+  output: Writable = process.stderr
+): Promise<string> {
   return new Promise((resolve) => {
-    const rl = createInterface({
-      input: process.stdin,
-      output: process.stderr,
-    });
-    process.stderr.write('Enter YNAB Personal Access Token: ');
-    rl.question('', (answer) => {
+    const rl = createInterface({ input, output });
+    rl.question(TOKEN_PROMPT, (answer) => {
       rl.close();
       resolve(answer.trim());
     });
@@ -50,7 +57,11 @@ export function createAuthCommand(): Command {
         }
 
         if (!token) {
-          throw new YnabCliError('Access token cannot be empty', 400);
+          throw new YnabCliError(
+            'Access token cannot be empty. Provide a token with ' +
+              '`ynab auth login --token <token>` or pipe one in via stdin.',
+            400
+          );
         }
         await auth.setAccessToken(token);
         client.clearApi();


### PR DESCRIPTION
## Problem

On an interactive TTY, `ynab auth login` looks like it hangs: no prompt appears, just a blank line with a blinking cursor. Reported on Warp; reproducible on any terminal that applies cursor/erase escape sequences promptly.

It isn't actually a non-TTY/stdin issue — `stdin`, `stdout`, and `stderr` are all TTYs in the affected sessions. The bug is in the interactive prompt itself.

### Root cause

```ts
const rl = createInterface({ input: process.stdin, output: process.stderr });
process.stderr.write('Enter YNAB Personal Access Token: ');  // written outside readline
rl.question('', (answer) => { ... });                        // empty query
```

The prompt is written directly to the output stream, *then* `readline.question('')` is called with an empty query. readline owns the current line and, when it renders, emits `ESC[1G` (cursor to column 1) + `ESC[0J` (erase to end of screen) — wiping the just-written prompt.

Captured from the real binary under a PTY, **before any input**:

```
Enter YNAB Personal Access Token: \x1b[1G\x1b[0J \x1b[1G
                                   └─ readline clears the line, erasing the prompt
```

Result: the prompt flashes and vanishes; the user sees nothing and assumes it's stuck. (Input still works — piping/typing a token authenticates — but nothing signals that a token is expected.)

## Fix

Pass the prompt as readline's `question()` query so readline reprints it after its own clear instead of erasing a string it doesn't know about:

```ts
const rl = createInterface({ input, output });
rl.question('Enter YNAB Personal Access Token: ', (answer) => { ... });
```

Same binary under a PTY after the fix — clear first, prompt second, surviving on screen with the cursor parked after it:

```
\x1b[1G\x1b[0J Enter YNAB Personal Access Token: \x1b[35G
```

`promptForToken()` and `readTokenFromStdin()` now accept injectable streams (defaulting to the real stdio) so the prompt-rendering and stdin-parsing paths can be unit-tested, and the empty-token error gains an actionable hint.

## Tests

Adds `src/commands/auth.test.ts`: the prompt text reaches the output stream and the typed token is returned/trimmed; stdin piping resolves/trims, empty-EOF resolves empty, and stream errors reject.

```
✓ src/commands/auth.test.ts (5 tests)
Test Files  4 passed (4)
     Tests  35 passed (35)
```

`bun run typecheck` and `bun run lint` (oxlint) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)